### PR TITLE
Fix:  Image fails to reload when resizing browser #7 

### DIFF
--- a/src/vue-masonry-wall.vue
+++ b/src/vue-masonry-wall.vue
@@ -168,9 +168,8 @@
        */
       redraw() {
         this.ready = false
-		//reset columns and cursor
         this.columns.splice(0)
-		this.cursor=0
+	this.cursor = 0
         this.columns.push(..._newColumns(this._columnSize()))
         this.ready = true
         this._fill()

--- a/src/vue-masonry-wall.vue
+++ b/src/vue-masonry-wall.vue
@@ -168,7 +168,9 @@
        */
       redraw() {
         this.ready = false
+		//reset columns and cursor
         this.columns.splice(0)
+		this.cursor=0
         this.columns.push(..._newColumns(this._columnSize()))
         this.ready = true
         this._fill()

--- a/src/vue-masonry-wall.vue
+++ b/src/vue-masonry-wall.vue
@@ -169,7 +169,7 @@
       redraw() {
         this.ready = false
         this.columns.splice(0)
-	this.cursor = 0
+        this.cursor = 0
         this.columns.push(..._newColumns(this._columnSize()))
         this.ready = true
         this._fill()


### PR DESCRIPTION
The cursor was not being reset while redrawing leading to an empty masonry wall if no new items existed

Fix for https://github.com/fuxingloh/vue-masonry-wall/issues/7