### PR TITLE
Added z-index: -1; for bottom so that it does not cover item.

### DIFF
--- a/examples/index.vue
+++ b/examples/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <h2>Masonry: append endlessly</h2>
+    <h2>Masonry: append 100</h2>
 
     <vue-masonry-wall :items="items" :options="options" @append="append">
       <template v-slot:default="{item}">
@@ -57,6 +57,10 @@ export default Vue.extend({
      * I am mocking a API call that load 20 objects at a time.
      */
     append() {
+      if (this.items.length > 100) {
+        return
+      }
+
       for (let i = 0; i < 20; i++) {
         this.items.push({title: `Item ${this.items.length}`, content: content()})
       }

--- a/src/vue-masonry-wall.vue
+++ b/src/vue-masonry-wall.vue
@@ -247,5 +247,6 @@
     margin-top: -300px;
     padding-top: 300px;
     min-height: 100px;
+    z-index: -1;
   }
 </style>


### PR DESCRIPTION
<!--
Give a brief description of the pull request. 
-->

Closes #21 

> During testing, I found that the masonry-bottom div blocks user interaction with the contents of the main masonry item. To fix this, I added z-indexdirectives in my style, fixing a z-index of 3 for .masonry-item and a z-index of 1 for .masonry-bottom. @mistressofjellyfish

Added `z-index: -1` for masonry-bottom instead.
