### PR TITLE
fix: issue of the ssr

### DIFF
--- a/src/vue-masonry-wall.vue
+++ b/src/vue-masonry-wall.vue
@@ -111,6 +111,10 @@
       }
 
       this.$resize()
+    
+      // set opacity to 1 when ssr.columns is recieved and  this.columns.length === this._columnSize() so redraw does not get called for the first time.
+      if(!this.ready) this.ready = true;
+      
       window.addEventListener('resize', this.$resize)
     },
     /**


### PR DESCRIPTION
when ssr.columns value is equal with _columnSize() return value redraw method does not get called for the first time and opacity of the masonry-wall will be zero so nothing would be visible on the page for the first time.

<!--
Give a brief description of the pull request. 
-->
